### PR TITLE
Refactor/deploy: change Dockerfile and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #stage1
-FROM golang:1.21-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 
 #install dependencies
@@ -17,7 +17,7 @@ COPY . .
 
 # Set necessary environment variables needed for our image and build the API server.
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
-RUN go build -ldflags="-s -w" -o ticketing ./cmd/app
+RUN go build -ldflags="-s -w" -o trinityknights.backend ./cmd/app
 
 #stage2
 FROM scratch
@@ -26,11 +26,10 @@ FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy binary and config files from /build to root folder of scratch container.
-COPY --from=builder ["/build/ticketing", "/"]
+COPY --from=builder ["/build/trinityknights.backend", "/"]
 
 # Command to run when starting the container.
-ENTRYPOINT ["/ticketing"]
+ENTRYPOINT ["/trinityknights.backend"]
 
 # Expose port 3000 to the outside world.
 EXPOSE 3000
-

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: clean swag mockgen critic security test
+.PHONY: docker.build docker.run docker.stop
+.PHONY: dc.build dc.up dc.down
+
 APP_NAME = trinityknights.backend
 APP_VERSION = 0.0.1
 
@@ -42,6 +46,4 @@ dc.up: dc.build
 
 dc.down:
 	docker compose down
-
-mockgen:
-	sh ./bin/generate-mock.sh
+	

--- a/internal/service/order/order_service_impl.go
+++ b/internal/service/order/order_service_impl.go
@@ -96,11 +96,11 @@ func (s *OrderServiceImpl) CreateOrder(ctx context.Context, request *model.Order
 	s.Log.Infof("Verifying tickets - IDs: %v, Seats: %v", request.TicketIDs, request.SeatNumbers)
 
 	for _, ticketID := range request.TicketIDs {
-		var ticket entity.Ticket
+		var t entity.Ticket
 		// Lock individual ticket for update
 		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 			Where("id = ? AND order_id IS NULL", ticketID).
-			First(&ticket).Error; err != nil {
+			First(&t).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, domainErrors.ErrSeatAlreadyTaken
 			}
@@ -109,8 +109,8 @@ func (s *OrderServiceImpl) CreateOrder(ctx context.Context, request *model.Order
 		}
 
 		// Add ticket to our target tickets slice
-		targetTickets = append(targetTickets, &ticket)
-		totalPrice += ticket.Price
+		targetTickets = append(targetTickets, &t)
+		totalPrice += t.Price
 	}
 
 	// Convert pointer slice to value slice


### PR DESCRIPTION
This pull request includes several changes to the `Dockerfile`, `Makefile`, and `order_service_impl.go` to update dependencies, rename binaries, and improve code readability.

### Dockerfile changes:
* Updated the Go version from 1.21 to 1.23.
* Renamed the output binary from `ticketing` to `trinityknights.backend`.
* Updated the `COPY` and `ENTRYPOINT` commands to reflect the new binary name.

### Makefile changes:
* Added `.PHONY` targets for various commands to improve makefile efficiency.
* Removed the `mockgen` target and its associated script call.

### Code readability improvement:
* Renamed the variable `ticket` to `t` in the `CreateOrder` function to enhance code readability and consistency. [[1]](diffhunk://#diff-51bd3409a521db8a54245678c0dc8aed10835e9a8681685d50e50d9b9c30c6e1L99-R103) [[2]](diffhunk://#diff-51bd3409a521db8a54245678c0dc8aed10835e9a8681685d50e50d9b9c30c6e1L112-R113)